### PR TITLE
Add .vscodeignore to exclude dev files from package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,10 @@
+# Development files
+.gitignore
+.editorconfig
+.vscode/
+.claude/
+CLAUDE.md
+CONTRIBUTING.md
+
+# Source files not needed in package
+**/*.less


### PR DESCRIPTION
## Summary

- Add `.vscodeignore` to exclude unnecessary development files from VSIX package
- Excluded: `.vscode/`, `.claude/`, `CLAUDE.md`, `CONTRIBUTING.md`, `.gitignore`, `.editorconfig`, `*.less`
- Reduces package size and optimizes distribution

## Files included in package

- package.json
- LICENSE
- README.md
- icon.png
- images/preview.png
- themes/RubyBlue-color-theme.json

Closes #7