### PR TITLE
Style vscode.dev badge with theme colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ruby Blue Theme
 
-[![Preview in vscode.dev](https://img.shields.io/badge/preview%20in-vscode.dev-82C6E0?style=for-the-badge&colorA=112435&colorB=82C6E0)](https://vscode.dev/theme/hirofumii.rubyblue-theme)
+[![Preview in vscode.dev](https://img.shields.io/badge/preview%20in-vscode.dev-blue?style=for-the-badge&colorA=112435&colorB=82C6E0)](https://vscode.dev/theme/hirofumii.rubyblue-theme)
 
 Dark, high contrast theme designed for readability.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ruby Blue Theme
 
+[![Preview in vscode.dev](https://img.shields.io/badge/preview%20in-vscode.dev-82C6E0?style=for-the-badge&colorA=112435&colorB=82C6E0)](https://vscode.dev/theme/hirofumii.rubyblue-theme)
+
 Dark, high contrast theme designed for readability.
 
 ![Screenshot](https://raw.githubusercontent.com/hiz8/vscode-theme-rubyblue/master/images/preview.png)


### PR DESCRIPTION
## Summary
- Update the vscode.dev preview badge to use Ruby Blue theme colors
- Apply `for-the-badge` style for better visibility
- Left side (colorA): #112435 (theme background)
- Right side (colorB): #82C6E0 (keywords/types color)

## Test plan
- [x] Verify badge renders correctly on GitHub README
- [x] Confirm colors match the Ruby Blue theme palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)