### PR TITLE
Add About Ruby Blue section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Dark, high contrast theme designed for readability.
 
 ![Screenshot](https://raw.githubusercontent.com/hiz8/vscode-theme-rubyblue/master/images/preview.png)
 
+## About Ruby Blue
+
+Ruby Blue is a classic dark theme originally created by John W. Long in 2006 for TextMate. The name pays homage to the Ruby programming language — it was designed to mimic the colors used in code samples on ruby-lang.org at the time.
+
+What sets Ruby Blue apart from typical dark themes is its distinctive deep navy blue background rather than pure black, paired with warm accent colors (orange, yellow, green) that create a unique aesthetic that's both easy on the eyes and highly readable.
+
+Over nearly two decades, Ruby Blue has earned its place as a trusted theme across the developer ecosystem:
+
+- Notepad++ — Included as a standard bundled theme
+- CodeMirror — Added in version 2.21 (2011), powering many web-based editors
+- Sublime Text, Vim, Brackets, and more
+
+This VS Code adaptation continues that tradition, bringing the classic Ruby Blue experience to modern development workflows.
+
 ## Install
 
 Install from the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items/hirofumii.rubyblue-theme).


### PR DESCRIPTION
This pull request adds a new "About Ruby Blue" section to the `README.md` file, providing background information on the theme's origins, distinctive features, and history of adoption across various editors.