### PR TITLE
Style README badges with theme colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Ruby Blue Theme
 
-[![Preview in vscode.dev](https://img.shields.io/badge/preview%20in-vscode.dev-blue?style=for-the-badge&colorA=112435&colorB=82C6E0)](https://vscode.dev/theme/hirofumii.rubyblue-theme)
+[![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/hirofumii.rubyblue-theme?style=for-the-badge&colorA=112435&colorB=82C6E0)](https://marketplace.visualstudio.com/items?itemName=hirofumii.rubyblue-theme)
+[![Open VSX](https://img.shields.io/open-vsx/v/hiz8/rubyblue-theme?style=for-the-badge&colorA=112435&colorB=F4C20B)](https://open-vsx.org/extension/hiz8/rubyblue-theme)
+[![Preview in vscode.dev](https://img.shields.io/badge/preview%20in-vscode.dev-blue?style=for-the-badge&colorA=16314a&colorB=A6E22E)](https://vscode.dev/theme/hirofumii.rubyblue-theme)
 
 Dark, high contrast theme designed for readability.
 


### PR DESCRIPTION
Add VS Marketplace and Open VSX badges, update all badges to use for-the-badge style with theme color palette for visual consistency.